### PR TITLE
Do not show required mark in labels when required option is set to false

### DIFF
--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -868,7 +868,7 @@ class BootstrapForm
 
         $label = $label ?: str_replace('_', ' ', Str::title($name));
 
-        if (isset($options['required'])) {
+        if (isset($options['required']) && $options['required']) {
             $label = sprintf('%s %s', $label, $this->getLabelRequiredMark());
         }
 
@@ -927,7 +927,7 @@ class BootstrapForm
             $class[] = $this->getFormGroupErrorClass($name);
         }
 
-        if (isset($options['required'])) {
+        if (isset($options['required']) && $options['required']) {
             $class[] = $this->getGroupRequiredClass();
 
             Arr::forget($options, 'required');


### PR DESCRIPTION
Fix: when required option was set to false on a field, required attribute wasn't set as planned, but required mark appeared on the label anyway.