### PR TITLE
Change Laravel helper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Bootstrap 4 forms for Laravel 5
 ==================================
 
-This is a package for simply creating Bootstrap 4 styled form groups in Laravel 5. It extends the normal form builder to provide you with horizontal form groups completed with labels, error messages and appropriate class usage.
+This is a package for simply creating Bootstrap 4 styled form groups in Laravel 5.7 and higher. It extends the normal form builder to provide you with horizontal form groups completed with labels, error messages and appropriate class usage.
 
 For Bootstrap 3, use [version 1.x](https://github.com/bnbwebexpertise/laravel-bootstrap-form/tree/1) : `composer require bnbwebexpertise/laravel-bootstrap-form:^1`
 

--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -921,6 +921,10 @@ class BootstrapForm
     protected function getFormGroupOptions($name = null, array $options = [])
     {
         $class = ['form-group'];
+        
+        if ($this->type == Type::HORIZONTAL) {
+            $class[] = 'row';
+        }
 
         if ($name) {
             $class[] = $this->getFormGroupErrorClass($name);

--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -1347,6 +1347,6 @@ class BootstrapForm
      */
     protected function getGroupOptions($options = [])
     {
-        return array_only($options, ['required', 'form-group-class']);
+        return Arr::only($options, ['required', 'form-group-class']);
     }
 }


### PR DESCRIPTION
Hello! I'm using Laravel 7 and when I tried to use BootForm I've got an exception, because helper function array_only is not exist anymore. I changed it to a new style Arr:only helper function. This change was done in **Laravel 5.7.**
To get correct horizontal form with bootstrap 4 there is necessary to add 'row' class near to'form-group'.
